### PR TITLE
Add Mongo conversation stream seed JSON

### DIFF
--- a/json-template/mirrorCore/foundation/conversations.json
+++ b/json-template/mirrorCore/foundation/conversations.json
@@ -1,0 +1,120 @@
+{
+  "_meta": {
+    "description": "MongoDB seed document capturing assistant/user conversation streams for MirrorCore",
+    "version": 1,
+    "lastUpdated": "2024-05-07T00:00:00.000Z"
+  },
+  "conversations": [
+    {
+      "_id": {
+        "$oid": "665000000000000000000001"
+      },
+      "session": {
+        "sessionId": "mirrorcore-seed-0001",
+        "title": "MirrorCore Loom Onboarding",
+        "startedAt": {
+          "$date": "2024-05-06T18:12:43.000Z"
+        },
+        "tags": ["onboarding", "loom", "mirrorcore"],
+        "source": "codex-one-shot"
+      },
+      "participants": {
+        "user": {
+          "id": "user-mirrorcore",
+          "displayName": "MirrorCore Architect"
+        },
+        "assistant": {
+          "id": "assistant-mirrorcore",
+          "model": "gpt-4-type-script-liaison"
+        }
+      },
+      "context": {
+        "project": "MirrorCore",
+        "layers": ["farm", "symbolic-ai", "archive"],
+        "hasPersistentMemory": false,
+        "notes": "Assistant does not retain memory across sessions; each conversation supplies context via prompt."
+      },
+      "messages": [
+        {
+          "messageId": 1,
+          "role": "system",
+          "timestamp": {
+            "$date": "2024-05-06T18:12:43.000Z"
+          },
+          "content": "System prompt establishing MirrorCore loom scaffold and repository goals.",
+          "tokenCounts": {
+            "promptTokens": 256,
+            "completionTokens": 0
+          }
+        },
+        {
+          "messageId": 2,
+          "role": "user",
+          "timestamp": {
+            "$date": "2024-05-06T18:13:21.000Z"
+          },
+          "content": "Create a layer-tagged TypeScript repo for the holographic loom.",
+          "tokenCounts": {
+            "promptTokens": 38,
+            "completionTokens": 0
+          }
+        },
+        {
+          "messageId": 3,
+          "role": "assistant",
+          "timestamp": {
+            "$date": "2024-05-06T18:14:05.000Z"
+          },
+          "content": {
+            "summary": "Generated MirrorCore TypeScript scaffold aligned to loom layers.",
+            "commits": [
+              {
+                "hash": "6a1b2c3",
+                "description": "Add domain layer modules"
+              }
+            ]
+          },
+          "tokenCounts": {
+            "promptTokens": 0,
+            "completionTokens": 112
+          }
+        },
+        {
+          "messageId": 4,
+          "role": "user",
+          "timestamp": {
+            "$date": "2024-05-07T00:02:10.000Z"
+          },
+          "content": "Create a JSON for capturing our conversation stream into a mongo db. Do you have persistent memory of the MirrorCore?",
+          "tokenCounts": {
+            "promptTokens": 36,
+            "completionTokens": 0
+          }
+        },
+        {
+          "messageId": 5,
+          "role": "assistant",
+          "timestamp": {
+            "$date": "2024-05-07T00:03:01.000Z"
+          },
+          "content": {
+            "response": "Outlined MongoDB conversation schema and clarified lack of persistent memory.",
+            "followUp": "Consider storing per-session summaries if long-term recall is desired."
+          },
+          "tokenCounts": {
+            "promptTokens": 0,
+            "completionTokens": 64
+          }
+        }
+      ],
+      "analytics": {
+        "totalTurns": 5,
+        "totalTokens": 506,
+        "durationSeconds": 342,
+        "lastUpdated": {
+          "$date": "2024-05-07T00:03:01.000Z"
+        }
+      }
+    }
+  ]
+}

--- a/mirrorcore/.env.example
+++ b/mirrorcore/.env.example
@@ -1,0 +1,7 @@
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=neo4j-password
+SQLITE_PATH=./data/mirrorcore.db
+NOTION_TOKEN=secret_notion_token
+NOTION_DATABASE_TASKS=
+NOTION_DATABASE_TIME=

--- a/mirrorcore/README.md
+++ b/mirrorcore/README.md
@@ -1,0 +1,41 @@
+# MirrorCore Loom v2
+
+MirrorCore Loom v2 captures the layer-tagged architecture for the holographic loom.
+It ships as a TypeScript project with adapters for Neo4j, Notion, and SQLite along
+with retrieval and pack-building utilities that align with the layer diagram.
+
+## Getting Started
+
+1. Install dependencies using pnpm (Node.js 20+).
+   ```sh
+   pnpm install
+   ```
+2. Copy `.env.example` to `.env` and fill in the secrets for Neo4j, Notion, and SQLite.
+3. Run the dev script to execute the sample pack build.
+   ```sh
+   pnpm dev
+   ```
+
+## Scripts
+
+- `pnpm dev` – boots the development harness in `scripts/dev.ts`.
+- `pnpm sync:notion` – synchronises Notion tasks and time entries into SQLite.
+- `pnpm build:pack` – runs an example pack build flow using mock data.
+
+## Database Setup
+
+Run the seed SQL into your local SQLite database before syncing Notion or retrieving
+from Neo4j. Apply the Cypher migration after seeding your Neo4j graph.
+
+# Holographic Loom — Layer Map
+- [10 Knot] src/domain/knot.ts — narrative/loop operators over graph selections.
+- [9 Category] Adapters + types provide objects/morphisms; index wires functors (adapters).
+- [8 Information] scoring: entropy/novelty, MMR redundancy penalty.
+- [7 Statistics] selectors + weight fitting hooks; simple regressions later.
+- [6 Topology] persistent motifs across scales; stable “shapes” of content.
+- [5 Geometry] metric choices over embedding manifolds; distance → similarity.
+- [4 Combinatorics] strict→relax ladder + greedy per-token pack.
+- [3 Graph] junction-first model + strict AND intersections in Neo4j.
+- [2 Calculus] exponential decays/time flow; smooth weighting.
+- [1 Linear Algebra] embeddings + cosine.
+- [0 Bedrock] env, IO, token estimates, schema mirrors.

--- a/mirrorcore/db/migrations/006_junction_first.cypher
+++ b/mirrorcore/db/migrations/006_junction_first.cypher
@@ -1,0 +1,9 @@
+CALL {
+  WITH 1000 AS batch
+  MATCH (t:Thread)-[r:CROSSES]->(k:Knot)
+  WITH t,k LIMIT batch
+  MERGE (j:Junction {threadId: t.id, knotId: k.id})
+  ON CREATE SET j.createdAt = datetime()
+  MERGE (t)-[:HAS_JUNCTION]->(j)
+  MERGE (j)-[:AT_KNOT]->(k)
+} IN TRANSACTIONS OF 1000 ROWS;

--- a/mirrorcore/db/seed.sql
+++ b/mirrorcore/db/seed.sql
@@ -1,0 +1,33 @@
+-- [0 Bedrock] Base relational schema for tasks, labor, and sales
+CREATE TABLE IF NOT EXISTS tasks (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  category TEXT,
+  status TEXT,
+  total_minutes INTEGER DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS labor (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  task_id TEXT NOT NULL REFERENCES tasks(id),
+  minutes INTEGER NOT NULL,
+  worker TEXT,
+  date TEXT
+);
+
+CREATE TABLE IF NOT EXISTS sales (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  crop TEXT,
+  quantity REAL,
+  revenue REAL,
+  date TEXT
+);
+
+CREATE VIEW IF NOT EXISTS task_minutes AS
+SELECT t.id AS task_id,
+       t.name,
+       SUM(l.minutes) AS total_minutes
+FROM tasks t
+LEFT JOIN labor l ON l.task_id = t.id
+GROUP BY t.id, t.name;

--- a/mirrorcore/package.json
+++ b/mirrorcore/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "mirrorcore-loom",
+  "version": "2.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx scripts/dev.ts",
+    "sync:notion": "tsx scripts/sync_notion_all.ts",
+    "build:pack": "tsx scripts/build_pack_example.ts"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@notionhq/client": "^2.2.14",
+    "better-sqlite3": "^9.4.0",
+    "dotenv": "^16.4.5",
+    "neo4j-driver": "^5.19.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "ts-node": "^10.9.2",
+    "tslib": "^2.6.2",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/mirrorcore/pnpm-lock.yaml
+++ b/mirrorcore/pnpm-lock.yaml
@@ -1,0 +1,1021 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@notionhq/client':
+        specifier: ^2.2.14
+        version: 2.3.0
+      better-sqlite3:
+        specifier: ^9.4.0
+        version: 9.6.0
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
+      neo4j-driver:
+        specifier: ^5.19.0
+        version: 5.28.2
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@24.5.2)(typescript@5.9.2)
+      tslib:
+        specifier: ^2.6.2
+        version: 2.8.1
+      tsx:
+        specifier: ^4.7.0
+        version: 4.20.5
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.2
+
+packages:
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@esbuild/aix-ppc64@0.25.10':
+    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.10':
+    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.10':
+    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.10':
+    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.10':
+    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.10':
+    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.10':
+    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.10':
+    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.10':
+    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.10':
+    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.10':
+    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.10':
+    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.10':
+    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.10':
+    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.10':
+    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.10':
+    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.10':
+    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.10':
+    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.10':
+    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.10':
+    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.10':
+    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.10':
+    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@notionhq/client@2.3.0':
+    resolution: {integrity: sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw==}
+    engines: {node: '>=12'}
+
+  '@tsconfig/node10@1.0.11':
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@24.5.2':
+    resolution: {integrity: sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==}
+
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  better-sqlite3@9.6.0:
+    resolution: {integrity: sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  detect-libc@2.1.0:
+    resolution: {integrity: sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==}
+    engines: {node: '>=8'}
+
+  diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.25.10:
+    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  neo4j-driver-bolt-connection@5.28.2:
+    resolution: {integrity: sha512-dEX06iNPEo9iyCb0NssxJeA3REN+H+U/Y0MdAjJBEoil4tGz5PxBNZL6/+noQnu2pBJT5wICepakXCrN3etboA==}
+
+  neo4j-driver-core@5.28.2:
+    resolution: {integrity: sha512-fBMk4Ox379oOz4FcfdS6ZOxsTEypjkcAelNm9LcWQZ981xCdOnGMzlWL+qXECvL0qUwRfmZxoqbDlJzuzFrdvw==}
+
+  neo4j-driver@5.28.2:
+    resolution: {integrity: sha512-nix4Canllf7Tl4FZL9sskhkKYoCp40fg7VsknSRTRgbm1JaE2F1Ej/c2nqlM06nqh3WrkI0ww3taVB+lem7w7w==}
+
+  node-abi@3.77.0:
+    resolution: {integrity: sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==}
+    engines: {node: '>=10'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.20.5:
+    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.12.0:
+    resolution: {integrity: sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+
+snapshots:
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@esbuild/aix-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm@0.25.10':
+    optional: true
+
+  '@esbuild/android-x64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.10':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.10':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.10':
+    optional: true
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@notionhq/client@2.3.0':
+    dependencies:
+      '@types/node-fetch': 2.6.13
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@tsconfig/node10@1.0.11': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 24.5.2
+
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 24.5.2
+      form-data: 4.0.4
+
+  '@types/node@24.5.2':
+    dependencies:
+      undici-types: 7.12.0
+
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.15.0
+
+  acorn@8.15.0: {}
+
+  arg@4.1.3: {}
+
+  asynckit@0.4.0: {}
+
+  base64-js@1.5.1: {}
+
+  better-sqlite3@9.6.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  chownr@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  create-require@1.1.1: {}
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
+  delayed-stream@1.0.0: {}
+
+  detect-libc@2.1.0: {}
+
+  diff@4.0.2: {}
+
+  dotenv@16.6.1: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  esbuild@0.25.10:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.10
+      '@esbuild/android-arm': 0.25.10
+      '@esbuild/android-arm64': 0.25.10
+      '@esbuild/android-x64': 0.25.10
+      '@esbuild/darwin-arm64': 0.25.10
+      '@esbuild/darwin-x64': 0.25.10
+      '@esbuild/freebsd-arm64': 0.25.10
+      '@esbuild/freebsd-x64': 0.25.10
+      '@esbuild/linux-arm': 0.25.10
+      '@esbuild/linux-arm64': 0.25.10
+      '@esbuild/linux-ia32': 0.25.10
+      '@esbuild/linux-loong64': 0.25.10
+      '@esbuild/linux-mips64el': 0.25.10
+      '@esbuild/linux-ppc64': 0.25.10
+      '@esbuild/linux-riscv64': 0.25.10
+      '@esbuild/linux-s390x': 0.25.10
+      '@esbuild/linux-x64': 0.25.10
+      '@esbuild/netbsd-arm64': 0.25.10
+      '@esbuild/netbsd-x64': 0.25.10
+      '@esbuild/openbsd-arm64': 0.25.10
+      '@esbuild/openbsd-x64': 0.25.10
+      '@esbuild/openharmony-arm64': 0.25.10
+      '@esbuild/sunos-x64': 0.25.10
+      '@esbuild/win32-arm64': 0.25.10
+      '@esbuild/win32-ia32': 0.25.10
+      '@esbuild/win32-x64': 0.25.10
+
+  expand-template@2.0.3: {}
+
+  file-uri-to-path@1.0.0: {}
+
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  fs-constants@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-tsconfig@4.10.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0: {}
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
+
+  make-error@1.3.6: {}
+
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mimic-response@3.1.0: {}
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
+
+  napi-build-utils@2.0.0: {}
+
+  neo4j-driver-bolt-connection@5.28.2:
+    dependencies:
+      buffer: 6.0.3
+      neo4j-driver-core: 5.28.2
+      string_decoder: 1.3.0
+
+  neo4j-driver-core@5.28.2: {}
+
+  neo4j-driver@5.28.2:
+    dependencies:
+      neo4j-driver-bolt-connection: 5.28.2
+      neo4j-driver-core: 5.28.2
+      rxjs: 7.8.2
+
+  node-abi@3.77.0:
+    dependencies:
+      semver: 7.7.2
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.0
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.77.0
+      pump: 3.0.3
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  safe-buffer@5.2.1: {}
+
+  semver@7.7.2: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-json-comments@2.0.1: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tr46@0.0.3: {}
+
+  ts-node@10.9.2(@types/node@24.5.2)(typescript@5.9.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 24.5.2
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  tslib@2.8.1: {}
+
+  tsx@4.20.5:
+    dependencies:
+      esbuild: 0.25.10
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  typescript@5.9.2: {}
+
+  undici-types@7.12.0: {}
+
+  util-deprecate@1.0.2: {}
+
+  v8-compile-cache-lib@3.0.1: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  wrappy@1.0.2: {}
+
+  yn@3.1.1: {}

--- a/mirrorcore/scripts/build_pack_example.ts
+++ b/mirrorcore/scripts/build_pack_example.ts
@@ -1,0 +1,13 @@
+import { buildPack } from '../src/pack/pack_builder.js';
+import { Candidate, Weights } from '../src/domain/scoring.js';
+
+const query = [1,0.2,0.1];
+const weights: Weights = { w_sym:0.6, w_txt:0.3, w_g:0.2, w_rec:0.1, w_use:0.1, w_div:0.2, lambda:0.5, tau:8*3600*1000 };
+const candidates: Candidate[] = [
+  { id:'a', tokens:120, symScore:0.9, textVec:[0.9,0.1,0.2], content:'Spell thread a' },
+  { id:'b', tokens:80, symScore:0.7, textVec:[0.8,0.2,0.1], content:'Spell thread b' },
+  { id:'c', tokens:60, symScore:0.4, textVec:[0.2,0.9,0.1], content:'Spell thread c' }
+];
+
+const pack = buildPack(query, candidates, 200, weights);
+console.log(JSON.stringify(pack, null, 2));

--- a/mirrorcore/scripts/dev.ts
+++ b/mirrorcore/scripts/dev.ts
@@ -1,0 +1,4 @@
+import { bootstrap } from '../src/index.js';
+
+await bootstrap();
+console.log('Dev harness complete.');

--- a/mirrorcore/scripts/sync_notion_all.ts
+++ b/mirrorcore/scripts/sync_notion_all.ts
@@ -1,0 +1,6 @@
+import { syncTasks } from '../src/notion/sync_tasks.js';
+import { syncTimeEntries } from '../src/notion/sync_time_entries.js';
+
+await syncTasks();
+await syncTimeEntries();
+console.log('Synced Notion tasks and time entries.');

--- a/mirrorcore/src/adapters/embeddings.ts
+++ b/mirrorcore/src/adapters/embeddings.ts
@@ -1,0 +1,24 @@
+/** [1 Linear Algebra] Simple embedding cache + cosine helper for experiments. */
+export type EmbeddingProvider = {
+  embed(text: string): Promise<number[]>;
+};
+
+export class InMemoryEmbeddingProvider implements EmbeddingProvider {
+  private store = new Map<string, number[]>();
+  constructor(private generator: (text: string) => number[]){ }
+
+  async embed(text: string){
+    let vec = this.store.get(text);
+    if (!vec){
+      vec = this.generator(text);
+      this.store.set(text, vec);
+    }
+    return vec;
+  }
+}
+
+export function cosineSimilarity(a: number[], b: number[]){
+  let dot=0,na=0,nb=0;
+  for (let i=0;i<a.length;i++){ dot+=a[i]*b[i]; na+=a[i]*a[i]; nb+=b[i]*b[i]; }
+  return dot/(Math.sqrt(na)*Math.sqrt(nb)+1e-9);
+}

--- a/mirrorcore/src/adapters/neo4j.ts
+++ b/mirrorcore/src/adapters/neo4j.ts
@@ -1,0 +1,16 @@
+import neo4j from 'neo4j-driver'; import { env } from '../env.js';
+export const driver = neo4j.driver(env.neo4j.uri, neo4j.auth.basic(env.neo4j.user, env.neo4j.password));
+export async function knotsCrossingThreads(requiredKnotIds: string[], requiredThreadIds: string[]) {
+  const s = driver.session();
+  try {
+    const res = await s.run(
+`MATCH (j:Junction)-[:AT_KNOT]->(k:Knot) WHERE k.id IN $knotIds
+ WITH j, collect(DISTINCT k.id) AS ks WHERE size(ks) = $kCount
+ MATCH (t:Thread)-[:HAS_JUNCTION]->(j) WHERE t.id IN $threadIds
+ WITH j, collect(DISTINCT t.id) AS ts WHERE size(ts) = $tCount
+ RETURN DISTINCT j LIMIT 500`,
+      { knotIds: requiredKnotIds, threadIds: requiredThreadIds, kCount: requiredKnotIds.length, tCount: requiredThreadIds.length }
+    );
+    return res.records.map(r => r.get('j').properties);
+  } finally { await s.close(); }
+}

--- a/mirrorcore/src/adapters/notion.ts
+++ b/mirrorcore/src/adapters/notion.ts
@@ -1,0 +1,17 @@
+import { Client } from '@notionhq/client';
+import { env } from '../env.js';
+
+export const notionClient = new Client({ auth: env.notion.token });
+
+export type NotionPage = Awaited<ReturnType<typeof notionClient.pages.retrieve>>;
+
+export async function listDatabasePages(databaseId: string){
+  const pages: any[] = [];
+  let cursor: string | undefined;
+  do {
+    const res = await notionClient.databases.query({ database_id: databaseId, start_cursor: cursor });
+    pages.push(...res.results);
+    cursor = res.has_more ? res.next_cursor ?? undefined : undefined;
+  } while (cursor);
+  return pages;
+}

--- a/mirrorcore/src/adapters/sqlite.ts
+++ b/mirrorcore/src/adapters/sqlite.ts
@@ -1,0 +1,30 @@
+import Database from 'better-sqlite3';
+import { env } from '../env.js';
+
+class SQLiteAdapter {
+  private db: Database.Database | null = null;
+
+  async connect(){
+    if (!this.db){
+      this.db = new Database(env.sqlite.path);
+      this.db.pragma('journal_mode = WAL');
+    }
+  }
+
+  async close(){
+    this.db?.close();
+    this.db = null;
+  }
+
+  run(sql: string, params: any[] = []){
+    if (!this.db) throw new Error('Database not connected');
+    return this.db.prepare(sql).run(...params);
+  }
+
+  all<T = any>(sql: string, params: any[] = []){
+    if (!this.db) throw new Error('Database not connected');
+    return this.db.prepare(sql).all(...params) as T[];
+  }
+}
+
+export const sqlite = new SQLiteAdapter();

--- a/mirrorcore/src/domain/category.ts
+++ b/mirrorcore/src/domain/category.ts
@@ -1,0 +1,8 @@
+/** Tiny categorical veneer: Adapters are functors between Worlds (Notion, Graph, Local).
+ * Objects: Entities (Task, TimeEntry, Junction). Morphisms: Sync/Query transforms.
+ */
+export type World = 'Notion'|'Graph'|'Local';
+export type Morphism<I,O> = (i:I)=>Promise<O>|O;
+export function compose<A,B,C>(g:Morphism<B,C>, f:Morphism<A,B>):Morphism<A,C>{
+  return async (a:A)=> g(await f(a));
+}

--- a/mirrorcore/src/domain/geometry.ts
+++ b/mirrorcore/src/domain/geometry.ts
@@ -1,0 +1,18 @@
+/** Metric over embeddings: swap cosine for e.g., hyperbolic or Mahalanobis. */
+export type Metric = 'cosine'|'euclidean'|'mahalanobis';
+export function distance(a:number[], b:number[], metric:Metric='cosine', covInv?:number[][]){
+  if (metric==='euclidean'){
+    let s=0; for (let i=0;i<a.length;i++) s+=(a[i]-b[i])**2; return Math.sqrt(s);
+  }
+  if (metric==='mahalanobis' && covInv){
+    // Very light Mahalanobis (no checks)
+    const diff = a.map((x,i)=>x-b[i]);
+    // diff^T Σ^{-1} diff
+    const t = covInv.map(row => row.reduce((acc,rij,j)=>acc+rij*diff[j],0));
+    const q = diff.reduce((acc,di,i)=>acc+di*t[i],0);
+    return Math.sqrt(Math.max(q,0));
+  }
+  // cosine distance = 1 - cosine similarity
+  let dot=0,na=0,nb=0; for (let i=0;i<a.length;i++){ dot+=a[i]*b[i]; na+=a[i]*a[i]; nb+=b[i]*b[i]; }
+  return 1 - dot/(Math.sqrt(na)*Math.sqrt(nb)+1e-9);
+}

--- a/mirrorcore/src/domain/knot.ts
+++ b/mirrorcore/src/domain/knot.ts
@@ -1,0 +1,19 @@
+export type KnotOp =
+  | { kind:'loop'; times:number }
+  | { kind:'bind'; tag:string }
+  | { kind:'gate'; require:string[] }; // symbolic gates before selection
+
+/** Applies a simple "knot ritual" over candidate ids: loop amplifies usageBoost. */
+export function applyKnotOps<T extends {id:string; usageBoost?:number}>(cands:T[], ops:KnotOp[]){
+  let out = cands.map(c => ({...c}));
+  for (const op of ops){
+    if (op.kind==='loop'){
+      out = out.map(c => ({...c, usageBoost: (c.usageBoost ?? 0) + 0.02*op.times }));
+    } else if (op.kind==='bind'){
+      // no-op placeholder: could tag for downstream filters
+    } else if (op.kind==='gate'){
+      // no-op placeholder: could filter by required symbolic ids
+    }
+  }
+  return out;
+}

--- a/mirrorcore/src/domain/scoring.ts
+++ b/mirrorcore/src/domain/scoring.ts
@@ -1,0 +1,22 @@
+export type Weights = { w_sym:number; w_txt:number; w_g:number; w_rec:number; w_use:number; w_div:number; lambda:number; tau:number; };
+export type Candidate = {
+  id: string; tokens: number; symScore: number;
+  textVec?: number[]; recencyMs?: number; graphDist?: number; usageBoost?: number; content?: string;
+};
+export function cosine(a:number[], b:number[]){ let dot=0,na=0,nb=0; for (let i=0;i<a.length;i++){ dot+=a[i]*b[i]; na+=a[i]*a[i]; nb+=b[i]*b[i]; } return dot/(Math.sqrt(na)*Math.sqrt(nb)+1e-9); }
+export function utilityBase(c: Candidate, qVec:number[], W: Weights){
+  const S_txt = (c.textVec && qVec) ? cosine(c.textVec, qVec) : 0;                  // [1 LA]
+  const S_g   = (c.graphDist!=null) ? Math.exp(-W.lambda*(c.graphDist)) : 0;       // [2 Calculus]
+  const D_rec = (c.recencyMs!=null) ? Math.exp(-(c.recencyMs)/(W.tau)) : 0;        // [2 Calculus]
+  const B_use = c.usageBoost ?? 0;                                                 // [7 Stats prior]
+  return W.w_sym*c.symScore + W.w_txt*S_txt + W.w_g*S_g + W.w_rec*D_rec + W.w_use*B_use;
+}
+export function mmrPenalty(c: Candidate, chosen: Candidate[], W: Weights){          // [8 Info]
+  if (chosen.length===0 || !c.textVec) return 0;
+  const maxSim = Math.max(...chosen.map(d => (d.textVec? cosine(c.textVec!, d.textVec) : 0)));
+  return W.w_div*maxSim;
+}
+export function marginalUtilityPerToken(c: Candidate, qVec:number[], chosen: Candidate[], W: Weights){
+  const u = utilityBase(c, qVec, W) - mmrPenalty(c, chosen, W);
+  return u / Math.max(c.tokens, 1);
+}

--- a/mirrorcore/src/domain/selectors.ts
+++ b/mirrorcore/src/domain/selectors.ts
@@ -1,0 +1,20 @@
+/** [7 Statistics] Basic selectors and smoothing hooks for loom datasets. */
+export type NumericSeries = { id: string; value: number }[];
+
+export function zScore(series: NumericSeries){
+  if (series.length===0) return new Map<string, number>();
+  const mean = series.reduce((acc, s)=>acc+s.value,0)/series.length;
+  const variance = series.reduce((acc,s)=>acc+(s.value-mean)**2,0)/series.length;
+  const std = Math.sqrt(variance || 1);
+  return new Map(series.map(s => [s.id, (s.value-mean)/std]));
+}
+
+export function exponentialSmoothing(series: NumericSeries, alpha=0.3){
+  let last = series[0]?.value ?? 0;
+  const out = new Map<string, number>();
+  for (const point of series){
+    last = alpha*point.value + (1-alpha)*last;
+    out.set(point.id, last);
+  }
+  return out;
+}

--- a/mirrorcore/src/domain/topology.ts
+++ b/mirrorcore/src/domain/topology.ts
@@ -1,0 +1,19 @@
+/** Persistent motif score: if an item keeps reappearing across buckets, boost it. */
+export type MotifObs = { id:string; bucket:number }; // bucket from time_bucket()
+export function persistentBoost(observations:MotifObs[], halfLifeBuckets=6){
+  const byId = new Map<string, number[]>();
+  for (const o of observations){
+    const xs = byId.get(o.id) ?? []; xs.push(o.bucket); byId.set(o.id, xs);
+  }
+  const now = Math.max(...observations.map(o=>o.bucket), 0);
+  const boost = new Map<string, number>();
+  for (const [id,bks] of byId){
+    let s = 0;
+    for (const b of bks){
+      const age = (now-b);
+      s += Math.exp(-age/halfLifeBuckets);
+    }
+    boost.set(id, s/(1+boost.size));
+  }
+  return boost; // map id -> small positive boost
+}

--- a/mirrorcore/src/domain/types.ts
+++ b/mirrorcore/src/domain/types.ts
@@ -1,0 +1,21 @@
+/** [9 Category] Shared type universe for loom entities. */
+export type Task = {
+  id: string;
+  name: string;
+  status: string;
+  tags: string[];
+  totalMinutes: number;
+};
+
+export type TimeEntry = {
+  id: string;
+  taskId: string;
+  minutes: number;
+  startedAt: number;
+};
+
+export type Junction = {
+  id: string;
+  knotId: string;
+  threadId: string;
+};

--- a/mirrorcore/src/env.ts
+++ b/mirrorcore/src/env.ts
@@ -1,0 +1,23 @@
+import 'dotenv/config';
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing environment variable ${name}`);
+  return value;
+}
+
+export const env = {
+  neo4j: {
+    uri: requireEnv('NEO4J_URI'),
+    user: requireEnv('NEO4J_USER'),
+    password: requireEnv('NEO4J_PASSWORD')
+  },
+  sqlite: {
+    path: requireEnv('SQLITE_PATH')
+  },
+  notion: {
+    token: requireEnv('NOTION_TOKEN'),
+    tasksDatabase: requireEnv('NOTION_DATABASE_TASKS'),
+    timeDatabase: requireEnv('NOTION_DATABASE_TIME')
+  }
+};

--- a/mirrorcore/src/index.ts
+++ b/mirrorcore/src/index.ts
@@ -1,0 +1,21 @@
+import { driver } from './adapters/neo4j.js';
+import { notionClient } from './adapters/notion.js';
+import { sqlite } from './adapters/sqlite.js';
+
+/** [9 Category] Entry point wiring the adapters as functors between worlds. */
+export async function bootstrap(){
+  await sqlite.connect();
+  await driver.verifyConnectivity();
+  console.log('MirrorCore Loom adapters ready.');
+  console.log(`Notion client ready: ${Boolean(notionClient)}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`){
+  bootstrap().catch(err => {
+    console.error(err);
+    process.exitCode = 1;
+  }).finally(async ()=>{
+    await driver.close();
+    await sqlite.close();
+  });
+}

--- a/mirrorcore/src/lib/clock.ts
+++ b/mirrorcore/src/lib/clock.ts
@@ -1,0 +1,15 @@
+/** [0 Bedrock] deterministic clock helpers for repeatable tests */
+export interface Clock {
+  now(): number;
+}
+
+export class SystemClock implements Clock {
+  now(){
+    return Date.now();
+  }
+}
+
+export class FixedClock implements Clock {
+  constructor(private value: number){}
+  now(){ return this.value; }
+}

--- a/mirrorcore/src/lib/time_bucket.ts
+++ b/mirrorcore/src/lib/time_bucket.ts
@@ -1,0 +1,10 @@
+export function timeBucket(epochMs: number, granularity: 'day'|'week'|'month') {
+  const d = new Date(epochMs);
+  if (granularity==='day') return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  if (granularity==='week') {
+    const day = d.getDay(); const offset = (day+6)%7;
+    const monday = new Date(d.getFullYear(), d.getMonth(), d.getDate()-offset);
+    return new Date(monday.getFullYear(), monday.getMonth(), monday.getDate()).getTime();
+  }
+  return new Date(d.getFullYear(), d.getMonth(), 1).getTime();
+}

--- a/mirrorcore/src/lib/util.ts
+++ b/mirrorcore/src/lib/util.ts
@@ -1,0 +1,12 @@
+/** [0 Bedrock] Generic helpers used across layers. */
+export function chunk<T>(arr: T[], size: number){
+  const res: T[][] = [];
+  for (let i=0;i<arr.length;i+=size){
+    res.push(arr.slice(i, i+size));
+  }
+  return res;
+}
+
+export function assertNever(x: never): never {
+  throw new Error(`Unexpected value: ${x}`);
+}

--- a/mirrorcore/src/notion/schemas.md
+++ b/mirrorcore/src/notion/schemas.md
@@ -1,0 +1,2 @@
+Tasks: Name, Key, Status, Tags, Total Hours (rollup)
+Time Entries: Name, Task(Relation), Start, End, Duration(formula), Tags

--- a/mirrorcore/src/notion/sync_tasks.ts
+++ b/mirrorcore/src/notion/sync_tasks.ts
@@ -1,0 +1,30 @@
+import { listDatabasePages } from '../adapters/notion.js';
+import { sqlite } from '../adapters/sqlite.js';
+import { env } from '../env.js';
+import { Task } from '../domain/types.js';
+
+function extractTask(page: any): Task {
+  const props = page.properties ?? {};
+  const name = props.Name?.title?.[0]?.plain_text ?? 'Untitled';
+  const status = props.Status?.status?.name ?? 'Unknown';
+  const tags = (props.Tags?.multi_select ?? []).map((t: any)=>t.name);
+  const totalMinutes = Math.round((props['Total Hours']?.number ?? 0) * 60);
+  return {
+    id: page.id,
+    name,
+    status,
+    tags,
+    totalMinutes
+  };
+}
+
+export async function syncTasks(){
+  await sqlite.connect();
+  const pages = await listDatabasePages(env.notion.tasksDatabase);
+  sqlite.run(`DELETE FROM tasks`);
+  const insert = `INSERT INTO tasks (id, name, category, status, total_minutes, created_at) VALUES (?, ?, ?, ?, ?, COALESCE(?, datetime('now')))`;
+  for (const page of pages){
+    const task = extractTask(page);
+    sqlite.run(insert, [task.id, task.name, task.tags[0] ?? null, task.status, task.totalMinutes, null]);
+  }
+}

--- a/mirrorcore/src/notion/sync_time_entries.ts
+++ b/mirrorcore/src/notion/sync_time_entries.ts
@@ -1,0 +1,26 @@
+import { listDatabasePages } from '../adapters/notion.js';
+import { sqlite } from '../adapters/sqlite.js';
+import { env } from '../env.js';
+
+function toMinutes(start: string | null, end: string | null){
+  if (!start || !end) return 0;
+  const s = new Date(start).getTime();
+  const e = new Date(end).getTime();
+  return Math.max(0, Math.round((e - s)/60000));
+}
+
+export async function syncTimeEntries(){
+  await sqlite.connect();
+  const pages = await listDatabasePages(env.notion.timeDatabase);
+  sqlite.run(`DELETE FROM labor`);
+  const insert = `INSERT INTO labor (task_id, minutes, worker, date) VALUES (?, ?, ?, ?)`;
+  for (const page of pages){
+    const props = page.properties ?? {};
+    const taskId = props.Task?.relation?.[0]?.id;
+    if (!taskId) continue;
+    const minutes = toMinutes(props.Start?.date?.start ?? null, props.End?.date?.start ?? null) || (props.Duration?.number ?? 0);
+    const worker = props.Tags?.multi_select?.[0]?.name ?? null;
+    const date = props.Start?.date?.start ?? null;
+    sqlite.run(insert, [taskId, minutes, worker, date]);
+  }
+}

--- a/mirrorcore/src/pack/pack_builder.ts
+++ b/mirrorcore/src/pack/pack_builder.ts
@@ -1,0 +1,16 @@
+import { Candidate, marginalUtilityPerToken, Weights } from '../domain/scoring.js';
+import { estimateTokens } from './tokenizers.js';
+export function buildPack(queryVec:number[], candidates: Candidate[], tokenBudget:number, W:Weights){
+  const pool = candidates.map(c => ({ ...c, tokens: c.tokens ?? estimateTokens(c.content ?? '') }));
+  const chosen: Candidate[] = [];
+  let remain = tokenBudget;
+  while (true) {
+    const viable = pool.filter(c => c.tokens<=remain && !chosen.find(d=>d.id===c.id));
+    if (!viable.length) break;
+    let best: Candidate|null = null; let bestScore = -Infinity;
+    for (const c of viable) { const score = marginalUtilityPerToken(c, queryVec, chosen, W); if (score>bestScore){ bestScore=score; best=c; } }
+    if (!best || bestScore<=0) break;
+    chosen.push(best); remain -= best.tokens;
+  }
+  return { chosen, used: tokenBudget - remain, remain };
+}

--- a/mirrorcore/src/pack/tokenizers.ts
+++ b/mirrorcore/src/pack/tokenizers.ts
@@ -1,0 +1,1 @@
+export function estimateTokens(s: string){ return Math.ceil((s||'').length/4); }

--- a/mirrorcore/src/retrieval/relax_strategies.ts
+++ b/mirrorcore/src/retrieval/relax_strategies.ts
@@ -1,0 +1,8 @@
+export type StrictQuery = { requiredKnots: string[]; requiredThreads: string[]; mustTags?: string[]; };
+export function relaxAll(q: StrictQuery): StrictQuery[] {
+  const out: StrictQuery[] = [q];
+  if (q.requiredKnots.length>0) out.push({ ...q, requiredKnots: q.requiredKnots.slice(0,-1) });
+  if (q.requiredThreads.length>0) out.push({ ...q, requiredThreads: q.requiredThreads.slice(0,-1) });
+  out.push({ ...q, requiredKnots: [], requiredThreads: [] });
+  return out;
+}

--- a/mirrorcore/src/retrieval/retrieval_intersect.ts
+++ b/mirrorcore/src/retrieval/retrieval_intersect.ts
@@ -1,0 +1,9 @@
+import { knotsCrossingThreads } from '../adapters/neo4j.js';
+import { relaxAll, StrictQuery } from './relax_strategies.js';
+export async function retrievalIntersect(q: StrictQuery, limit=200) {
+  for (const step of relaxAll(q)) {
+    const js = await knotsCrossingThreads(step.requiredKnots, step.requiredThreads);
+    if (js.length) return js.slice(0, limit);
+  }
+  return [];
+}

--- a/mirrorcore/tsconfig.json
+++ b/mirrorcore/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "baseUrl": "./src",
+    "outDir": "dist"
+  },
+  "include": ["src", "scripts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add a MongoDB-oriented conversation stream seed document to the MirrorCore JSON templates
- capture session metadata, message history, token accounting, and clarify lack of persistent assistant memory

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc4ff9ee7c83329bb9c915c43c0c5b