### PR TITLE
Add time bucketing utilities for temporal threads

### DIFF
--- a/HoloLoom/Utils/time_bucket.py
+++ b/HoloLoom/Utils/time_bucket.py
@@ -1,0 +1,91 @@
+"""Utility helpers for coarse-grained time bucketing.
+
+The knowledge-graph migration scripts stored under ``archive/`` rely on
+YYYY-MM-DD-{morning|afternoon|evening|night} buckets to attach events to
+"threads" representing temporal continuity.  Several upcoming ingestion
+pipelines need the same logic when constructing in-memory graphs, so we
+provide a shared implementation here.
+
+``time_bucket`` accepts ``datetime`` objects (naive or timezone aware),
+ISO-8601 strings, or UNIX epoch seconds.  All inputs are normalised to
+UTC before the bucket label is generated so that backend services agree
+on the same coarse time slices regardless of local timezone.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Union
+
+TimeInput = Union[datetime, int, float, str]
+
+
+def to_utc_datetime(value: TimeInput) -> datetime:
+    """Normalise supported inputs to a timezone-aware ``datetime``.
+
+    Args:
+        value: A ``datetime`` instance (naive or aware), an ISO-8601 string,
+            or a UNIX timestamp expressed as ``int``/``float`` seconds.
+
+    Returns:
+        ``datetime`` instance with ``tzinfo`` set to UTC.
+
+    Raises:
+        TypeError: If the value type is unsupported.
+        ValueError: If a string cannot be parsed as a datetime.
+    """
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise ValueError("Datetime string is empty")
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError(f"Invalid datetime string: {value}") from exc
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    raise TypeError(f"Unsupported datetime value type: {type(value)!r}")
+
+
+def time_bucket(value: TimeInput) -> str:
+    """Bucket a timestamp into ``YYYY-MM-DD-{part_of_day}``.
+
+    The day-part boundaries mirror the legacy TypeScript implementation
+    shipped with the Neo4j ingestion tooling:
+
+    * ``morning`` – 05:00 ≤ hour < 12:00
+    * ``afternoon`` – 12:00 ≤ hour < 17:00
+    * ``evening`` – 17:00 ≤ hour < 22:00
+    * ``night`` – 22:00 ≤ hour or hour < 05:00
+
+    Args:
+        value: Supported timestamp representation.
+
+    Returns:
+        Bucket label string.
+    """
+    dt = to_utc_datetime(value)
+    hour = dt.hour
+
+    if 12 <= hour < 17:
+        part = "afternoon"
+    elif 17 <= hour < 22:
+        part = "evening"
+    elif hour >= 22 or hour < 5:
+        part = "night"
+    else:
+        part = "morning"
+
+    return f"{dt:%Y-%m-%d}-{part}"
+
+
+__all__ = ["time_bucket", "to_utc_datetime", "TimeInput"]

--- a/HoloLoom/tests/test_time_bucket.py
+++ b/HoloLoom/tests/test_time_bucket.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timezone, timedelta
+
+from HoloLoom.Utils.time_bucket import time_bucket, to_utc_datetime
+from HoloLoom.memory.graph import KG
+
+
+def test_time_bucket_from_iso_string():
+    bucket = time_bucket("2024-03-10T16:30:00Z")
+    assert bucket == "2024-03-10-afternoon"
+
+
+def test_time_bucket_from_epoch_seconds():
+    ts = datetime(2024, 3, 10, 23, 45, tzinfo=timezone.utc).timestamp()
+    bucket = time_bucket(ts)
+    assert bucket == "2024-03-10-night"
+
+
+def test_to_utc_datetime_normalises_inputs():
+    naive = datetime(2024, 3, 10, 6, 0, 0)
+    aware = to_utc_datetime(naive)
+    assert aware.tzinfo == timezone.utc
+    assert aware.hour == 6
+
+    offset = datetime(2024, 3, 10, 21, 0, 0, tzinfo=timezone(timedelta(hours=-5)))
+    aware_offset = to_utc_datetime(offset)
+    assert aware_offset.hour == 2  # converted to UTC
+    assert aware_offset.tzinfo == timezone.utc
+
+
+def test_connect_entity_to_time_creates_thread_and_edge():
+    kg = KG()
+    thread_id = kg.connect_entity_to_time("episode:1", "2024-03-10T22:15:00Z")
+
+    assert thread_id == "time::2024-03-10-night"
+    assert thread_id in kg.G
+    assert kg.G.nodes[thread_id]["bucket"] == "2024-03-10-night"
+
+    assert ("episode:1", thread_id) in kg.G.edges()
+    edge_data = list(kg.G.get_edge_data("episode:1", thread_id).values())[0]
+    assert edge_data["type"] == "IN_TIME"
+    assert edge_data["bucket"] == "2024-03-10-night"
+    assert edge_data["timestamp"].startswith("2024-03-10T22:15:00")
+
+    # entity index updated both ways
+    assert thread_id in kg._entity_index["episode:1"]
+    assert "episode:1" in kg._entity_index[thread_id]
+
+
+def test_connect_entity_to_time_reuses_thread_node():
+    kg = KG()
+    kg.connect_entity_to_time("episode:1", "2024-03-10T09:00:00Z")
+    kg.connect_entity_to_time("episode:2", "2024-03-10T11:59:59Z")
+
+    thread_id = "time::2024-03-10-morning"
+    assert thread_id in kg.G
+    assert "episode:1" in kg._entity_index[thread_id]
+    assert "episode:2" in kg._entity_index[thread_id]
+    assert kg.G.number_of_nodes() == 3  # two entities + one time thread
+


### PR DESCRIPTION
## Summary
- add a reusable UTC-normalising `time_bucket` helper for future ingestion pipelines
- extend the in-memory knowledge graph with a `connect_entity_to_time` helper that mirrors the Neo4j migrations
- cover the new functionality with unit tests for bucket calculation and graph wiring

## Testing
- python -m pytest HoloLoom/tests/test_time_bucket.py *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68f41f487efc8332945e469296d9b050