### PR TITLE
Add Chronos quick analysis overview

### DIFF
--- a/chronos/ANALYSIS.md
+++ b/chronos/ANALYSIS.md
@@ -1,0 +1,31 @@
+# Chronos Quick Analysis
+
+## Overview
+Chronos is a minimal, append-only time tracking system implemented as a Python package. It exposes the five verbs documented in the README (`start`, `stop`, `log`, `note`, and `link`) via a state manager and a CLI entry point.
+
+## Core State Management
+- `chronos.core.state.ChronosState` is the main façade for time tracking. It initializes an `EventLog`, reloads any still-open `start` events, and keeps the currently active task in memory for fast status queries.【F:chronos/core/state.py†L15-L52】
+- Each verb method returns a human-readable confirmation message mirroring the CLI output. The state object automatically formats timestamps and durations for these responses.【F:chronos/core/state.py†L54-L157】
+- `start` implicitly calls `stop` to auto-close an existing active task before tracking a new one, keeping the log consistent without user intervention.【F:chronos/core/state.py†L66-L89】
+- `stop` computes duration based on the stored start timestamp, clears the active task, and emits a `stop` event linked back to the originating `start` event via `start_id`.【F:chronos/core/state.py†L91-L135】
+- `log` supports retroactive entries by accepting a duration in seconds and optional timestamp override; when omitted, it back-calculates the start time by subtracting the duration from the current time.【F:chronos/core/state.py†L137-L171】
+- `note` and `link` perform validation against the log before appending, ensuring references resolve to known events. Notes default to the active task when available.【F:chronos/core/state.py†L173-L220】
+- `status` reports the active task with elapsed time, or an idle indicator when nothing is running.【F:chronos/core/state.py†L222-L233】
+
+## Event Log Details
+- `chronos.core.event_log.EventLog` handles persistence in a JSON Lines file located in the user’s home directory (or supplied path). Each `append` call assigns a new `chr_XXXX` identifier and, if necessary, stamps the current UTC timestamp.【F:chronos/core/event_log.py†L15-L74】
+- Events are represented by the `ChronosEvent` dataclass, which only serializes non-null fields. This keeps stored lines compact while supporting varied payloads for different event types.【F:chronos/core/event_log.py†L9-L43】
+- The log reader tolerates malformed lines by skipping JSON decode failures, preventing a single bad entry from breaking the history view.【F:chronos/core/event_log.py†L76-L109】
+
+## Voice & CLI Notes
+- Voice input flows through `chronos/voice.py`, translating natural-language commands into verb invocations. The README lists supported patterns, emphasizing short imperative phrases and hashtag-based tags.【F:chronos/README.md†L74-L139】
+- The CLI is Click-optional; the module can run directly with `python -m chronos`. README quick start commands demonstrate both typed and voice-driven workflows.【F:chronos/README.md†L24-L121】
+
+## Data Guarantees
+- All operations append to `~/.chronos/events.jsonl`, never mutating previous entries, satisfying the "append-only" principle called out in the README.【F:chronos/README.md†L48-L93】【F:chronos/core/event_log.py†L31-L74】
+- Event IDs are monotonically increasing integers with `chr_` prefix, enabling easy referencing and external linking without collisions across sessions.【F:chronos/core/event_log.py†L45-L73】
+
+## Observations & Potential Follow-ups
+- Because `_load_active_task` scans the entire log to find open sessions, performance might degrade with very large histories. Introducing an index or caching layer could help for heavy users.【F:chronos/core/state.py†L27-L45】
+- Duration parsing for `log` and voice commands likely lives in the CLI layer; ensuring consistent parsing between text and voice inputs would be a good regression target for future tests.【F:chronos/voice.py†L1-L200】
+- Tests exist under `chronos/tests`, but expanding them to cover cross-verb scenarios (e.g., auto-stop on `start`) would guard the critical behaviors highlighted above.


### PR DESCRIPTION
## Summary
- add a Chronos analysis document capturing the key behaviors of the core state, event log, and voice interface
- highlight append-only data guarantees and observations for potential follow-ups

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f5c55914483328a16df8ee1206f81)