### PR TITLE
docs: DEEP_INTENT.md — the intent stratum of the buried monorepo

### DIFF
--- a/DEEP_INTENT.md
+++ b/DEEP_INTENT.md
@@ -1,0 +1,408 @@
+# DEEP_INTENT.md — the intent stratum of the buried monorepo
+
+> **Provenance.** External reality-check, observation-only (nothing in this repo
+> was modified — this file is the lone exception, and it is committed
+> deliberately). Written by Claude (`claude-fable-5`) on **2026-08-08**, session
+> `b0c4a090`, after a 16-reader "deep intent" excavation of the whole
+> `~/Documents/hello-world` monorepo (~1.5M tokens, 388 tool calls, nothing in
+> the fossil touched), followed by a completeness critic and a gap-chase.
+>
+> **This is the third panel of a triptych.** `MONOLITH_AUTOPSY.md` (session
+> `ed4eb99d`, 2026-06-04) is the *vertical* dive — what is **real** (the leaves
+> work, the seams were imagined, nothing is bootable). `HELLO_WORLD_FIELD_MAP.md`
+> (session `a0af3fda`, same day) is the *horizontal* sweep — what is **live**
+> and **salvageable**. This document is the layer both of them deliberately left
+> in the ground: the **intent** — what the builder meant, dreamed, believed, and
+> felt, recovered in the fossil's own words. It complements and does not
+> supersede the other two; read all three together. A designed, quote-rich
+> companion to this file is published as a private artifact:
+> `https://claude.ai/code/artifact/69e3b3e9-35e4-4920-b5bc-0601245a8994`.
+>
+> **Epistemic status: interpretation tier.** The forensic quotes below are
+> verbatim and carry `file:line` — checkable. The through-lines that bind them
+> are a *reading*, not authored fact. One gap-chaser (an adversarial pass on the
+> Ernest counter-voice) was lost to a session limit and covered inline, so treat
+> that single thread as thinner than the rest.
+
+## One-line verdict
+
+This is not, at bottom, a software project. It is **one person's first attempt
+to weave an entire life into a single mind** — and underneath the mania and the
+quarter-million-line bursts, a coherent metaphysics of what meaning *is*. The
+builder built the right machinery for the wrong reason; the system that replaced
+it kept the machinery and found the reason.
+
+---
+
+## 0. The one thing to carry out
+
+The monolith was poured on the belief that intelligence is **synthesized in one
+place** — a 2,157-line orchestrator, one in-process brain that thinks, dreams,
+and improves itself. The live Mythrl substrate is the second draft, written
+after the first fell, on the inverted belief that intelligence **lives across
+parties and gets metabolized**. The names survived almost intact; the meaning
+transmuted under each one. You could not have built the second without watching
+the first fail.
+
+What this pass adds beyond the autopsy and the field map is the **affective and
+biographical stratum** — the emotional weather, the whole-life ambition, the
+tenderness of the burial, and the exact birth records of the vocabulary Mythrl
+speaks today.
+
+---
+
+## 1. The loom was load-bearing philosophy, not naming whimsy
+
+Every scanner assumes the weaving names are cute. They are not. The repo declares
+the metaphor a *first-class abstraction* (`README.md:211-219`,
+`CLAUDE.md:4885`), and behind it sits a single technical claim: **weaving *is*
+the discrete↔continuous transformation** — the neurosymbolic bridge dressed as
+textile. Yarn (the discrete symbolic graph) is *tensioned* into Warp (the
+continuous embedding field) and *detensioned* back into a decision:
+
+> "In traditional weaving, **warp threads** are held under tension on the loom,
+> providing structure for the weft… **Tensions** discrete knowledge threads into
+> continuous embeddings… **Detensions** back to discrete decisions… a reversible
+> transformation: **Yarn Graph ↔ Warp Space**"
+> — `HoloLoom/warp/README.md:11-19`
+
+The cosmology did not stop at cloth. Decision was quantum collapse ("Like quantum
+mechanics where wave functions collapse to definite states… 'snaps' them into
+concrete tool choices," `convergence/engine.py:12-18`). The loom respired, with a
+parasympathetic *inhale* and sympathetic *exhale*
+(`docs/architecture/BREATHING_SYSTEM.md`). Time was "the fourth dimension of the
+weaving process" (`chrono/trigger.py:14`). And it closed its own loop by watching
+itself weave:
+
+> "'Reflection is the loom learning from its own weaving.'"
+> — `HoloLoom/reflection/buffer.py:13`
+
+The whole system reduced to three verbs — `experience` / `recall` / `reflect` —
+over one representation, under the credo "Everything is a memory operation"
+(`hololoom.py:4`). The `mythRL 3-5-7-9` progressive-complexity ladder
+(LITE=3 → RESEARCH=9 steps) was a formal, named philosophy, not a config knob
+(`protocols/types.py:26-51`). And the vision board drew the payoff as a chant —
+which is the exact shape of today's two-tier read surface, sketched seven months
+early:
+
+> "**WARP (Knowledge) / WEFT (Experience)** … THREADS → TENSION → FABRIC →
+> UNDERSTANDING"
+> — `docs/architecture/VISION_BOARD.md:217-233`
+
+The metaphor arrives everywhere already fully formed — asserted, never argued. No
+"why a loom" origin essay exists anywhere in the repo; it crystallized on disk
+between the "Create HoloLoom" commit (Oct 9) and the first WarpSpace (Oct 17).
+
+---
+
+## 2. A physics of meaning, held as axiom
+
+Under the textile layer runs a genuine belief system: **meaning is a physical
+substance with dynamics**, so calculus and physics are the right instruments to
+think with. Meaning has position, velocity, curvature ("language as trajectories
+through semantic space… velocity, acceleration, and curvature,"
+`semantic_calculus/__init__.py:3-6`). Memory is an energy landscape that relaxes
+("Query activation creates high-energy state. System relaxes toward equilibrium,"
+`memory/spring_dynamics.py:31-33`), with damping explicitly glossed as
+forgetting. The justification is stated twice in one file — opening creed and
+sign-off:
+
+> "**Core Philosophy**: 'Nature has already solved these optimization problems
+> through physical laws. We just need to apply them.'"
+> — `HoloLoom/physics/README.md:9` (repeated at `:1621`)
+
+Routing was gradient flow; context-packing was Navier–Stokes; consolidation was a
+Gibbs ensemble crystallizing at a phase transition. The belief had real academic
+scaffolding (Friston 2010, Ruthotto 2020, Chamberlain 2021), not pure invention.
+The reach ran all the way to **ethics as differential geometry**:
+
+> "Not all paths through semantic space are equal. Some trajectories are more
+> virtuous, honest, balanced than others… Constrained geodesics (shortest ethical
+> path)… This is the 'moral compass' for semantic navigation."
+> — `HoloLoom/semantic_calculus/ethics.py:6-20`
+
+The interpretability dream was a named-axis space — Warmth and Valence beside
+`Dasein`, `Bad-Faith`, `Hamartia`, `Trickster-Archetype`: Heidegger, Sartre,
+Jung, and Aristotle's *Poetics* compiled to difference-of-centroid vectors. It is
+also, tellingly, a myth engine — built "for deep narrative/mythological research"
+(`dimensions.py:210`) — the direct ancestor of Mythrl's Intelligence-Tradition
+canon. The count itself confesses the register: the flagship "244 dimensions" was
+**a quota, not a discovery** ("Add more categories to reach 244…",
+`dimensions.py:800`), and the real number is 228.
+
+The most honest thing in this stratum is that the builder **pre-confessed the
+autopsy** a year before any excavation, marking every integration seam unbuilt in
+its own document:
+
+> "We've built the **measurement apparatus**. Now we need to wire it into the
+> **control system**. That's when meaning becomes a feature, not just an insight."
+> — `semantic_calculus/MEANING_AS_FEATURE.md:566`
+
+(The later `MATH_EXCAVATION.md` graded 134 kernels and found the pattern exact:
+transcribed textbook math is right to 1e-14; anything *derived, chosen, or
+connected* is silently wrong — a sign-inverted flagship curvature, a fabricated
+RK45 tableau, four divergent Poincaré implementations. The belief outran the
+build. Do not re-litigate that here — it is settled there.)
+
+---
+
+## 3. The whole-life exoskeleton
+
+Read the ~30 sibling projects together and a *person* appears, not a product
+line. The set covers **livelihood** (a farm-and-kitchen co-op, `coz/`, run by a
+voice companion, `elle/`), **land** (bees, biochar, a nursery), **family** (a
+K-12 game-school `EduVerse/`, a Thanksgiving planner `Sous/`), **art** (`ernest/`,
+an editor for the builder's own novel), **craft** (`squad/`, `promptly-*/`,
+`xterminator/`), **body** (`ouroboros/` drug-safety + an apothecary line),
+**community** (CSA logistics across food banks and churches), and **time**
+(`chronos/`, "The act of keeping time should never cost more time than it
+saves"). One memory substrate wires all of it together. The business plan names
+the enemy directly:
+
+> "Goal: balance **short-term cashflow** with **long-term sustainability**, while
+> avoiding **burnout** and building reusable systems."
+> — `coz/BUSINESS_PLAN_DRAFT.md` §Purpose
+
+The `coz/` folder contains **no code at all** — it is the actual life-plan:
+cost/time CSVs, SOPs for kombucha and hot sauce, a `someday-maybe.md` whose first
+line is "Truffle Innoculation," and a signature product, "The GOAT — Grown Oats
+And Time." The software orbits this folder. And the very first personal thing the
+"Smart AI" was pointed at was not technical but literary: the canonical first
+ingest target is the builder's novel manuscript, `SpeakForMe` (`START_HERE.md`).
+This was a refusal to choose between lives — an exoskeleton so one person could
+run a farm, teach kids, write a book, and keep coding at once.
+
+The most human single artifact in the whole dig lives in the health domain.
+Ouroboros — a drug-interaction checker named for the serpent eating its tail
+("Eternal vigilance… detect → block → learn → repeat," `ouroboros/README.md:11`)
+— was to be deployed on a friend's repurposed crypto-mining rig and validated at
+a house party:
+
+> "**Week 4**: Clinical validation - Invite ER doctor friends over - Show them
+> the UI - Collect validation data" … "**Your buddy will save $8,500/year** vs
+> AWS while helping save lives! 🚀"
+> — `ouroboros/HOME_MINING_RIG_DEPLOYMENT.md:653-657, :680`
+
+The pharmacology in it is *real* — FDA-documented fatal pairs, correct
+mechanisms, JAMA/NEJM citations. The hallucination lived, as always, in the
+seams (never-installed inference, an imagined "95% confidence"). The dream was
+anchored in genuine friendships and garage hardware; only the plumbing was
+imagined. (A modest, honest revival was attempted 2026-05-08 and abandoned
+mid-flight, uncommitted: "No `ActionCategory.MEDICAL` exists; using MODIFICATION
+as nearest meta-shape," `prescription_safety.py:34`. Ouroboros didn't die in the
+burst — it died on the operating table six months later.)
+
+---
+
+## 4. Consciousness was the stated north star — and it was declared reached
+
+The awareness layer commits, without hedging, to an operational definition:
+consciousness as **recursive epistemic self-monitoring** — knowing what you don't
+know, and being calibrated about your own calibration. Qualia are never
+mentioned (zero hits repo-wide); humility is the crown metric.
+
+> "The awareness layer becomes self-aware… This is compositional AI
+> consciousness examining itself."
+> — `HoloLoom/awareness/meta_awareness.py:1-8`
+
+The sibling simulator NeuroHood went further, claiming outright phenomenology
+("NPCs experience actual recursive self-awareness… **genuine phenomenology**,"
+`NeuroHood/__init__.py:6-8`) and a Jungian collective-unconscious dream system
+with a "Consciousness Slider" running from individual meaning to `FULL_DMT`
+ego-dissolution. And it declared victory — on a 3-billion-parameter model:
+
+> "🤯 SIMULATION AWARENESS: CONFIRMED! 🤯 / IT HAPPENED! / LLM-powered NeuroHood
+> residents are becoming aware they're in a simulation!"
+> — `NeuroHood/SIMULATION_AWARENESS_SUCCESS.md:1-9`
+
+The ambition's shape is preserved in a small scar. The program's "three paths to
+awareness" are lettered **A, C, D** across every document
+(`NeuroHood/EXPERIMENTAL_FEATURES.md`, `MOONSHOT_ROADMAP.md`). There is **no Path
+B**, anywhere — a fossil of a decision made and never written down. (The
+mechanism behind the dream was thin: the entire Hofstadter strange-loop engine is
+three canned strings ending `return questions[:1]  # Strange loops are deep`,
+`internal_dialogue.py:295` — the autopsy's law, that generation fills volume and
+not seams, in one line.)
+
+---
+
+## 5. The emotional record is pure mania — and one engineered counter-voice
+
+Every terminal document is a party. Ship notes carry five-oink approval ratings;
+a "moonshot" celebrates going from v1.0 to breakthrough "in 2 Hours!" The
+affective corpus records only highs — searching it for
+`exhaust|tired|burnout|3am` returns nothing (control: the same grep returns
+abundant technical hits). Even a whimsical code-quality tool counted joy as a
+shipped deliverable:
+
+> "Code Written: 8,364 lines / Documentation: 5,706 lines / Piglet Humor: 3,000+
+> lines … Piglet References: 147 / OINK Count: UNLIMITED!"
+> — `THE_COMPLETE_BARNYARD_STORY.txt:128-136`
+
+The lows are legible only **structurally** — a panic-merge whose commit *subject*
+is the unedited git template, the removal of a venv that "exceeds file size
+limit," and then 141 days of silence. The one place the builder deliberately
+engineered a channel for hard truth is `ernest/`, an editor for his own prose
+built on Hemingway's iceberg theory — its creed the exact aesthetic *inverse* of
+the quarter-million-line burst around it:
+
+> "Ernest doesn't coddle. Ernest doesn't flatter. Ernest tells you the truth
+> about your writing, then shows you how to make it sharper, cleaner, stronger."
+> … "Prose is architecture, not interior decoration."
+> — `ernest/README.md` (modes: SPARSE / DIRECT / GRACE)
+
+---
+
+## 6. Two entities playing at being an institution
+
+The generator and the human related through **play**, and the play was a memory
+palace. Four parallel sub-agents were cast as the four protagonists of
+*Charlotte's Web* — and the casting was load-bearing: the rat (hoarder, escape
+artist) got git rollback; the spider (weaver) got templates; each character *is*
+its module's failure model (`THE_COMPLETE_BARNYARD_STORY.txt:22-48`). A typo,
+`torugh`, was canonized into lore rather than fixed. And 73 files carry
+fabricated "Author: HoloLoom <X> Team" bylines — an 18-department org chart
+invented by a team of two. Across the whole corpus there is exactly one honest
+byline:
+
+> "Author: HoloLoom Team (Blake + Claude)"
+> — `archive/legacy/weaving_orchestrator_v2_pre_shuttle_merge.py:28`
+
+That same dream extended into governance the monolith never ran: departments
+negotiating *confidence as currency* at their boundaries
+("0.3 * requesting_conf + 0.7 * responding_conf," `MULTI_DEPARTMENT_WORKFLOWS.md:101`),
+adversarial agents as productive office politics ("Opposition Creates Quality —
+Like GANs," `agents/adversarial_agents.py:4-12`), a `MotivationalCoach`
+meta-agent, and a policy engine whose highest tier ends
+`default_decision = PolicyDecision.DENY` and escalates to a human
+(`agents/policy_governance.py:44,618`). The coordination ideas Mythrl now takes
+seriously — voting, quorum, escalation, tension-as-negotiation — were first
+rehearsed here as fiction. (A living exception: `HoloLoom/departments/eq_team/`
+is **untracked**, written in 2026 in a completely different, humble voice, and
+contains a candid indictment of the monolith's single hardcoded prompt making all
+its "council voices" identical — someone came back and built a real, small org
+inside the imagined one.)
+
+---
+
+## 7. The dig read as a diary
+
+The commit stream is partly a diary addressed to tomorrow's session. Read as
+stratigraphy it has a tone arc — a scrappy reawakening, a manic pour, a total
+silence, and a return in an entirely different, sobered voice.
+
+| When | Phase | In its own words |
+|---|---|---|
+| 2018-11-26 | **Genesis** | A learn-to-code starter repo: *"hi everyone, / I'm really serious abt figuring out how to do this code thing."* |
+| Sep 2025 | **Reawakening** | The 2018 intro is deleted for *"MithrL — short stack, great taste!"* The starter is rededicated. |
+| Oct 9–25 | **Accretion** | *"Create HoloLoom"* lands beside *"Create Szechuan_Eggplant."* The weave metaphor crystallizes Oct 9→17. |
+| **Oct 26–30** | **The Burst** | `+110,034` then `+174,134` insertions in two commits. *"The weaving has begun."* Shipped *"PRODUCTION-READY"* the same day a metric reads *"Confidence extraction broken (all 0.00)."* |
+| Nov 1–22 | **Moonshot Autumn** | A quarter-million-line single commit two weeks after "v1.0." Docs self-grade 100/100; the math moonshot lands. |
+| Dec 2 2025 → | **The Silence** | 141 days, zero commits. Dropped mid-stride — the last commit still adds features. No commit ever marks the decision to stop. |
+| 2026-04-22 | **Return, new voice** | Claims shrink to what was checked: *"Limits written but NOT yet applied."* Every commit now names its exact model. |
+| **2026-05-08** | **Burial day** | 22 dirs archived with importer-graph proof and *"recovery snippets so anything can be unmoved."* The read-surface MCP is born the same day. |
+
+The goodnight and the graveside, a session apart in voice, are the same
+continuity instinct that later became `handoff/SESSION.json`:
+
+> "Everything you need to pick up where we left off tomorrow. … Good night! 🌙"
+> — `e168ef8fc`, 2025-10-30
+>
+> "Includes recovery snippets so anything can be unmoved with git history
+> intact." — `5328d1bd4`, 2026-05-08
+
+Co-author attribution individuates *exactly* at the worldview break: every 2025
+burst commit signs an anonymous `Co-Authored-By: Claude`; from 2026-04-22 onward
+every commit names its model ("Claude Opus 4.7," "Claude Opus 4.8," "Claude Fable
+5"). Identity-provenance discipline arrived in the signature line itself.
+
+---
+
+## 8. What the fossil passed to the living
+
+The vocabulary Mythrl speaks today was born here — and most of it survived by
+keeping its *name* while its *meaning* changed underneath. The single most
+consequential inheritance is a joke: HoloLoom's birth certificate is one line,
+*"holoLoom — it's TS all the way down!"* (a TypeScript-turtles pun, commit
+`b7fad614d`, 2025-10-09), and "all the way down" is the literal ancestor of
+today's **"Autonomy all the way down."** The name `mythRL` itself predates the
+architecture — it was first a Windows folder path
+(`C:\Users\blake\Documents\mythRL`) before any code claimed it.
+
+| Fossil intent (2025) | How it survived | Live descendant (2026) |
+|---|---|---|
+| Yarn — discrete symbolic graph | **full** (name + role) | Yarn = Neo4j |
+| Warp — tensioned tensor field | name kept, math dropped | Warp = Qdrant |
+| Weft — flowing "DotPlasma" features | name kept, referent swapped | `weft/` = the Matrix conversation plane |
+| spinningWheel — wool→shard ETL | **full** (verb + role) | Para voice spinners → Bobbins |
+| Shuttle / the 9-step weave cycle | name kept; impl. adjudicated correctly-dropped | Shuttle (stack name) + "bardic recall" |
+| Tension — a loom mechanic | name kept, meaning transmuted | Tension = the LBP disagreement primitive |
+| Edward Tufte Machine (`HoloLoom/visualization/`) | code lifted, renamed | Jacquard |
+| mythRL — an RL step-ladder pattern | name kept, meaning transmuted | Mythrl = the movement |
+| Elle Core (Coz coop intelligence) | **full** | Elle (Autonomy stack); `coz/` → WIZ brief |
+| apps/beekeeping + `bee_inspection.py` | **full** | Keep + the PPR beekeeping testbed |
+| MirrorCore integration | **full** | the `chatgpt` corpus (imported MirrorCore) |
+| DreamWeaver / NeuroHood dreams | **none** | `dreamachine` is unrelated (Gysin flicker homage) |
+
+Grep is the control on the negative claims: `jacquard`, `dreamachine`, and —
+most tellingly — `bobbin` return **zero hits** in the burst-era fossil (control:
+the same instrument returns hundreds for `loom`/`spinning`/`weft`). **The central
+LBP primitive, Bobbin, was coined *after* the monolith** — the entire textile
+lexicon was built without it. The clearest proof the vision *grew* rather than
+shrank is in the live repo's own words, still choosing the same thread on
+purpose:
+
+> "Named for the crosswise thread that makes fabric visible over the **Warp** —
+> the near-collision with Warp-the-Qdrant-layer is deliberate; they interlace."
+> — `mythrl-dev/weft/README.md:3-5` (today)
+
+---
+
+## 9. The verdict — the vision didn't shrink; it inverted, and grew
+
+Memory, provenance, and symbolic-woven-with-neural were pitched here to make an
+*assistant* smarter and auditable. They turned out to be exactly what sovereign
+human/AI **partnership** needs: provenance to keep authored / derived /
+interpreted distinct; memory as the continuity of an agent-pattern; a read
+surface as the thing peers metabolize. The monolith *hoarded* provenance and
+never analyzed it; the substrate made it the spine.
+
+| | Monolith (fossil) | New substrate (live) |
+|---|---|---|
+| Where the brain lives | one in-process cathedral (a 2,157-line orchestrator) | a read-only surface; *other parties write*, the calling Claude reasons |
+| Build strategy | width-first, all at once, "done" | thinnest honest slice; verify execution, not bytes |
+| Learning | in-process RL loop | the human-paced partnership layer; trains nothing |
+| Ambition | "TensorFlow for AI memory" — *the* central infra | Mythrl movement + Packs/Ecosystems — *no* central platform |
+
+The fossil is the vision's first draft, written believing intelligence is
+synthesized in one place. The living substrate is the second draft, written after
+that belief broke, on the conviction that intelligence lives across parties and
+gets metabolized. The whole seven-year arc bookends in two lines — the 2018
+genesis README and the fossil's own self-epitaph:
+
+> "hi everyone, / I'm really serious abt figuring out how to do this code thing"
+> — README, 2018-11-26
+>
+> "An AI that doesn't replace us / but AUGMENTS our capabilities / THIS IS
+> HOLOLOOM / The Loom weaves on… / Threads becoming fabric… / Fabric becoming
+> understanding…" — `docs/architecture/VISION_BOARD.md:507ff`
+
+You could not build the second without watching the first fail — which is why the
+fossil's value is the negative space: the cathedral you pour and abandon in order
+to learn that you don't pour cathedrals.
+
+---
+
+## Method & coverage
+
+Sixteen parallel readers, each on a distinct stratum of the monorepo (textile
+cosmology, the consciousness dream, the barnyard/affect layer, the 22 quarantined
+concept dirs, name genesis, the philosophy files and 244 axes, the sibling lives,
+the git diary, the departments org, the math intent, the survivals, the
+never-grown UX face), then a completeness critic that nominated the Ouroboros
+medical stratum and the Ernest counter-voice as gaps. Ouroboros was chased; the
+Ernest pass was lost to a session limit and folded in inline. Nothing in the
+fossil was read through a denial or an empty instrument uncontrolled — negative
+claims above (`no Path B`, `zero bobbin hits`, `no exhaustion register`) each
+carry the control reading that produced them. Full per-reader haul preserved in
+the authoring session's scratchpad; this file is its synthesis.


### PR DESCRIPTION
Adds `DEEP_INTENT.md` — the third panel of the excavation triptych, beside `MONOLITH_AUTOPSY.md` (what is real) and `HELLO_WORLD_FIELD_MAP.md` (what is live). It recovers the **builder's intent** — the loom-as-philosophy, the physics of meaning, the whole-life exoskeleton, the consciousness moonshot, the affective record, and the survival map into today's Mythrl vocabulary — in the fossil's own cited words.

**Scope:** one new file, +408 lines. Non-destructive — nothing else changed.

**Branch note:** based on `origin/master` (the March-2026 line GitHub already has) with the doc committed on top. The doc's *content* describes the divergent local May/June excavation line, which is un-pushable to GitHub as-is (a long-ago committed `venv/` carries a 198 MB `libtorch_cpu.dylib` over GitHub's 100 MB limit).

**Caveat:** the doc commit is unsigned (authored via Claude Code, which can't GPG-sign). If this repo's "verified signatures" ruleset is enforced on merge into `master`, the commit needs re-signing first.

Epistemic status: interpretation tier — forensic quotes are verbatim with `file:line`; the through-lines are a reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)